### PR TITLE
⬆️ Sync with upstream v0.19.0-rc3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
 
     <!-- Spring Boot Framework 6.2.0 compatable with Spring Boot 3.4.0 -->
     <!-- https://spring.io/blog/2024/11/14/spring-framework-6-2-0-available-now -->
-    <spring-framework.version>6.2.1</spring-framework.version>
-    <spring-boot-dependencies.version>3.4.1</spring-boot-dependencies.version>
+    <spring-framework.version>6.2.3</spring-framework.version>
+    <spring-boot-dependencies.version>3.4.3</spring-boot-dependencies.version>
 
     <azure-sdk-bom.version>1.2.31</azure-sdk-bom.version>
     <azure-spring-boot.version>5.19.0</azure-spring-boot.version>
-    <springdoc-openapi-starter-webmvc-ui.version>2.7.0</springdoc-openapi-starter-webmvc-ui.version>
+    <springdoc-openapi-starter-webmvc-ui.version>2.8.5</springdoc-openapi-starter-webmvc-ui.version>
 
     <microsoft-graph.version>6.23.0</microsoft-graph.version>
     <azure.appinsights.version>3.6.2</azure.appinsights.version>
@@ -64,19 +64,15 @@
     <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <json.version>20231013</json.version>
-    <log4j-slf4j-impl.version>2.24.2</log4j-slf4j-impl.version>
-    <resilience4j.version>2.0.0</resilience4j.version>
-    <redisson.version>3.40.2</redisson.version>
-    <guava.version>33.3.1-jre</guava.version>
+    <log4j-slf4j-impl.version>2.24.3</log4j-slf4j-impl.version>
+    <resilience4j.version>2.3.0</resilience4j.version>
+    <redisson.version>3.45.0</redisson.version>
+    <guava.version>33.4.0-jre</guava.version>
 
     <!-- Plugin Versions -->
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
     <checkstyle-plugin.version>3.1.0</checkstyle-plugin.version>
-
-    <!-- Security fixes -->
-    <lettuce.version>6.5.1.RELEASE</lettuce.version>
-    <netty.version>4.1.118.Final</netty.version>
   </properties>
 
 
@@ -126,30 +122,6 @@
       </dependency>
       <!-- End of BOMs -->
       <!-- Dependencies, after the BOMs -->
-      <dependency>
-          <groupId>io.lettuce</groupId>
-          <artifactId>lettuce-core</artifactId>
-          <version>${lettuce.version}</version>
-          <!-- Overriding version to fix GHSA-q4h9-7rxj-7gx2
-              Spring Boot 3.4.0 uses lettuce-core 6.4.1 which is vulnerable to Redis Command Injection -->
-      </dependency>
-      <!-- Security fixes -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${netty.version}</version>
-        <!-- Overriding version to fix CVE-2024-24970
-            Netty before 4.1.108 is vulnerable to HTTP Request Smuggling.
-            This could lead to cache poisoning, security bypass, and request forgery. -->
-      </dependency>
-      <dependency>
-        <groupId>net.minidev</groupId>
-        <artifactId>json-smart</artifactId>
-        <version>2.5.2</version>
-        <!-- Overriding version to fix CVE-2024-57699
-            json-smart before 2.5.2 is vulnerable to Denial of Service (DoS) -->
-      </dependency>
-      <!-- Security fixes -->
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION


Generating Description
=======================
Using anthropic (claude-3-5-sonnet-20241022)...
Change Summary:

1. **Framework Version Updates**
   - Spring Framework upgraded from 6.2.1 to 6.2.3
   - Spring Boot Dependencies upgraded from 3.4.1 to 3.4.3
   - SpringDoc OpenAPI UI upgraded from 2.7.0 to 2.8.5

2. **Library Version Updates**
   - Log4j SLF4J implementation upgraded to 2.24.3
   - Resilience4j upgraded to 2.3.0
   - Redisson upgraded to 3.45.0
   - Guava upgraded to 33.4.0-jre

3. **Dependency Removals**
   - Removed Lettuce version override (6.5.1.RELEASE)
   - Removed Netty version override (4.1.118.Final)
   - Removed explicit json-smart dependency

Security Analysis:
⚠️ Two vulnerabilities detected:
- CVE-2025-24970 (High): Netty handler vulnerability in versions prior to 4.1.118.Final can lead to native crashes
- CVE-2025-25193 (Medium): Netty common vulnerability in versions up to 4.1.115.Final can cause denial of service on Windows

✓ Previous security overrides for Lettuce and Netty have been removed as they are now handled by updated parent dependencies